### PR TITLE
correct  ARMO/WEAP layouts

### DIFF
--- a/include/RE/T/TESObjectARMO.h
+++ b/include/RE/T/TESObjectARMO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RE/B/BGSTypedKeywordValueArray.h"
+#include "RE/B/BGSAttachParentArray.h"
 #include "RE/B/BGSBipedObjectForm.h"
 #include "RE/B/BGSBlockBashData.h"
 #include "RE/B/BGSDestructibleObjectForm.h"
@@ -88,9 +88,8 @@ namespace RE
 		// members
 		BGSEditorID                            formEditorID;   // 278
 		BSTOptional<TESObjectARMOInstanceData> instanceData;   // 288
-		std::uint64_t                          unk308;         // 308
 		BSTArray<ArmorAddon>                   modelArray;     // 310
-		BGSTypedKeywordValueArray<KeywordType::kAttachPoint> attachParents;  // 328
+		BGSAttachParentArray                   attachParents;  // 320
 		std::uint64_t                          unk340;         // 340
 		std::uint64_t                          unk348;         // 348
 		std::uint64_t                          unk350;         // 350
@@ -101,8 +100,7 @@ namespace RE
 	};
 	static_assert(offsetof(TESObjectARMO, formEditorID) == 0x280);
 	static_assert(offsetof(TESObjectARMO, instanceData) == 0x290);
-	static_assert(offsetof(TESObjectARMO, unk308) == 0x310);
-	static_assert(offsetof(TESObjectARMO, modelArray) == 0x318);
-	static_assert(offsetof(TESObjectARMO, attachParents) == 0x328);
+	static_assert(offsetof(TESObjectARMO, modelArray) == 0x310);
+	static_assert(offsetof(TESObjectARMO, attachParents) == 0x320);
 	static_assert(sizeof(TESObjectARMO) == 0x378);
 }

--- a/include/RE/T/TESObjectARMO.h
+++ b/include/RE/T/TESObjectARMO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RE/B/BGSAttachParentArray.h"
+#include "RE/B/BGSTypedKeywordValueArray.h"
 #include "RE/B/BGSBipedObjectForm.h"
 #include "RE/B/BGSBlockBashData.h"
 #include "RE/B/BGSDestructibleObjectForm.h"
@@ -88,9 +88,9 @@ namespace RE
 		// members
 		BGSEditorID                            formEditorID;   // 278
 		BSTOptional<TESObjectARMOInstanceData> instanceData;   // 288
-		BSTArray<ArmorAddon>                   modelArray;     // 308
-		BGSAttachParentArray                   attachParents;  // 318
-		std::uint64_t                          unk338;         // 338
+		std::uint64_t                          unk308;         // 308
+		BSTArray<ArmorAddon>                   modelArray;     // 310
+		BGSTypedKeywordValueArray<KeywordType::kAttachPoint> attachParents;  // 328
 		std::uint64_t                          unk340;         // 340
 		std::uint64_t                          unk348;         // 348
 		std::uint64_t                          unk350;         // 350
@@ -99,5 +99,10 @@ namespace RE
 		std::uint64_t                          unk368;         // 368
 		std::uint64_t                          unk370;         // 370
 	};
-	static_assert(sizeof(TESObjectARMO) == 0x380);
+	static_assert(offsetof(TESObjectARMO, formEditorID) == 0x280);
+	static_assert(offsetof(TESObjectARMO, instanceData) == 0x290);
+	static_assert(offsetof(TESObjectARMO, unk308) == 0x310);
+	static_assert(offsetof(TESObjectARMO, modelArray) == 0x318);
+	static_assert(offsetof(TESObjectARMO, attachParents) == 0x328);
+	static_assert(sizeof(TESObjectARMO) == 0x378);
 }

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -32,7 +32,6 @@ namespace RE
 	class BGSObjectInstance;
 	class BGSScene;
 	class BSAnimationGraphEvent;
-	class BSTransformDeltaEvent;
 	class NiAVObject;
 	class TESModel;
 	class TESObjectCELL;
@@ -134,14 +133,13 @@ namespace RE
 
 	class TESObjectREFR :
 		public TESHandleForm,                                                    // 00
-		public BSTEventSink<BSTransformDeltaEvent>,                              // 30
 		public IMovementProcessMessageInterface,                                 // 38
 		public IPostAnimationChannelUpdateFunctor,                               // 40
 		public BSTEventSink<BSAnimationGraphEvent>,                              // 48
 		public BSTEventSink<BGSInventoryListEvent::Event>,                       // 50
 		public IAnimationGraphManagerHolder,                                     // 58
-		public IKeywordFormBase,                                                 // 60
-		public ActorValueOwner,                                                  // 68
+		public ActorValueOwner,                                                  // 60
+		public IKeywordFormBase,                                                 // 68
 		public BSTEventSourceLazyInit<ActorValueEvents::ActorValueChangedEvent>  // 70
 	{
 	public:
@@ -394,6 +392,7 @@ namespace RE
 		[[nodiscard]] bool                            WornHasKeyword(BGSKeyword* a_keyword);
 
 		// members
+		std::uint64_t                                 unk78;          // 78
 		OBJ_REFR                                      data;           // 80
 		BSGuarded<BGSInventoryList*, BSReadWriteLock> inventoryList;  // A0
 		TESObjectCELL*                                parentCell;     // B0

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -32,6 +32,7 @@ namespace RE
 	class BGSObjectInstance;
 	class BGSScene;
 	class BSAnimationGraphEvent;
+	class BSTransformDeltaEvent;
 	class NiAVObject;
 	class TESModel;
 	class TESObjectCELL;
@@ -133,13 +134,14 @@ namespace RE
 
 	class TESObjectREFR :
 		public TESHandleForm,                                                    // 00
+		public BSTEventSink<BSTransformDeltaEvent>,                              // 30
 		public IMovementProcessMessageInterface,                                 // 38
 		public IPostAnimationChannelUpdateFunctor,                               // 40
 		public BSTEventSink<BSAnimationGraphEvent>,                              // 48
 		public BSTEventSink<BGSInventoryListEvent::Event>,                       // 50
 		public IAnimationGraphManagerHolder,                                     // 58
-		public ActorValueOwner,                                                  // 60
-		public IKeywordFormBase,                                                 // 68
+		public IKeywordFormBase,                                                 // 60
+		public ActorValueOwner,                                                  // 68
 		public BSTEventSourceLazyInit<ActorValueEvents::ActorValueChangedEvent>  // 70
 	{
 	public:
@@ -392,7 +394,6 @@ namespace RE
 		[[nodiscard]] bool                            WornHasKeyword(BGSKeyword* a_keyword);
 
 		// members
-		std::uint64_t                                 unk78;          // 78
 		OBJ_REFR                                      data;           // 80
 		BSGuarded<BGSInventoryList*, BSReadWriteLock> inventoryList;  // A0
 		TESObjectCELL*                                parentCell;     // B0

--- a/include/RE/T/TESObjectWEAP.h
+++ b/include/RE/T/TESObjectWEAP.h
@@ -266,11 +266,16 @@ namespace RE
 		~TESObjectWEAP() override;  // 00
 
 		// members
-		BGSEditorID                                formEditorID;       // 230
-		BSTSmartPointer<TESObjectWEAPInstanceData> weaponData;         // 240
-		BGSAttachParentArray                       attachParents;      // 248
-		BGSMod::Attachment::Mod*                   embeddedWeaponMod;  // 268
-		std::uint8_t                               unk270;             // 270
+		BGSEditorID                                formEditorID;       // 238
+		BSTSmartPointer<TESObjectWEAPInstanceData> weaponData;         // 248
+		BGSAttachParentArray                       attachParents;      // 250
+		BGSMod::Attachment::Mod*                   embeddedWeaponMod;  // 270
+		std::uint8_t                               unk278;             // 278
 	};
+	static_assert(offsetof(TESObjectWEAP, formEditorID) == 0x238);
+	static_assert(offsetof(TESObjectWEAP, weaponData) == 0x248);
+	static_assert(offsetof(TESObjectWEAP, attachParents) == 0x250);
+	static_assert(offsetof(TESObjectWEAP, embeddedWeaponMod) == 0x270);
+	static_assert(offsetof(TESObjectWEAP, unk278) == 0x278);
 	static_assert(sizeof(TESObjectWEAP) == 0x280);
 }


### PR DESCRIPTION

- updateTESObjectARMO to match the runtime-validated layout:
modelArray is BSTArray<ArmorAddon> at 0x310
attachParents is a full BGSAttachParentArray at 0x320
0x320 is the component vtable, with begin/end/cap at 0x328/0x330/0x338

- update TESObjectWEAP for BGSAttachParentArray at 0x250, with shifted formEditorID / weaponData offsets


Tried to validate by inspecting runtime memory layouts