### PR TITLE
fix TESObject/TESBoundObject component offsets

### DIFF
--- a/include/RE/T/TESBoundObject.h
+++ b/include/RE/T/TESBoundObject.h
@@ -44,12 +44,17 @@ namespace RE
 		virtual void          Unk_81();                                                             // 81
 
 		// members
-		NiPoint3                   boundMin;           // 048
-		NiPoint3                   boundMax;           // 054
-		BGSMod::Template::Items    templateItems;      // 060
-		BGSPreviewTransform        previewTransform;   // 080
-		BGSObjectPlacementDefaults placementDefaults;  // 0C8
-		std::uint32_t              unk0D8;             // 0D8
+		NiPoint3                   boundMin;           // 050
+		NiPoint3                   boundMax;           // 05C
+		BGSMod::Template::Items    templateItems;      // 068
+		BGSPreviewTransform        previewTransform;   // 088
+		BGSObjectPlacementDefaults placementDefaults;  // 0D0
+		std::uint32_t              unk0E0;             // 0E0
 	};
+	static_assert(offsetof(TESBoundObject, boundMin) == 0x50);
+	static_assert(offsetof(TESBoundObject, boundMax) == 0x5C);
+	static_assert(offsetof(TESBoundObject, templateItems) == 0x68);
+	static_assert(offsetof(TESBoundObject, previewTransform) == 0x88);
+	static_assert(offsetof(TESBoundObject, placementDefaults) == 0xD0);
 	static_assert(sizeof(TESBoundObject) == 0xE8);
 }

--- a/include/RE/T/TESObject.h
+++ b/include/RE/T/TESObject.h
@@ -25,7 +25,8 @@ namespace RE
 		virtual void Unk_6B();                      // 6B
 
 		// members
-		BGSSnapTemplateComponent snapTemplate;  // 030
+		BGSSnapTemplateComponent snapTemplate;  // 038
 	};
+	static_assert(offsetof(TESObject, snapTemplate) == 0x38);
 	static_assert(sizeof(TESObject) == 0x50);
 }


### PR DESCRIPTION
TESObject and TESBoundObject were shifted by +0x8 in the local headers