### PR TITLE
Fix BSTArray operator= and add keyword management helpers

### DIFF
--- a/include/RE/B/BGSKeywordForm.h
+++ b/include/RE/B/BGSKeywordForm.h
@@ -23,12 +23,13 @@ namespace RE
 		void                 InitializeDataComponent() override;     // 02 - { return; }
 
 		// add
-		virtual BGSKeyword* GetDefaultKeyword() const;  // 0B
-
+		virtual BGSKeyword*         GetDefaultKeyword() const;  // 0B
+		bool                        AddKeyword(RE::BGSKeyword* keyword);
 		[[nodiscard]] bool          ContainsKeywordString(std::string_view a_editorID);
 		void                        ForEachKeyword(std::function<BSContainer::ForEachResult(BGSKeyword*)> a_callback);
 		[[nodiscard]] std::uint32_t GetNumKeywords() const;
 		[[nodiscard]] bool          HasKeywordString(std::string_view a_editorID);
+		bool                        RemoveKeyword(RE::BGSKeyword* keyword);
 
 		// members
 		BSTArray<BGSFormFolderKeywordList*> formFolderKeywordLists;  // 10

--- a/include/RE/B/BGSKeywordForm.h
+++ b/include/RE/B/BGSKeywordForm.h
@@ -23,7 +23,8 @@ namespace RE
 		void                 InitializeDataComponent() override;     // 02 - { return; }
 
 		// add
-		virtual BGSKeyword*         GetDefaultKeyword() const;  // 0B
+		virtual BGSKeyword* GetDefaultKeyword() const;  // 0B
+
 		bool                        AddKeyword(RE::BGSKeyword* keyword);
 		[[nodiscard]] bool          ContainsKeywordString(std::string_view a_editorID);
 		void                        ForEachKeyword(std::function<BSContainer::ForEachResult(BGSKeyword*)> a_callback);

--- a/include/RE/B/BGSKeywordForm.h
+++ b/include/RE/B/BGSKeywordForm.h
@@ -24,13 +24,13 @@ namespace RE
 
 		// add
 		virtual BGSKeyword*         GetDefaultKeyword() const;  // 0B
-		bool                        AddKeyword(RE::BGSKeyword* keyword);
+		bool                        AddKeyword(BGSKeyword* keyword);
 		[[nodiscard]] bool          ContainsKeywordString(std::string_view a_editorID);
 		void                        ForEachKeyword(std::function<BSContainer::ForEachResult(BGSKeyword*)> a_callback);
 		[[nodiscard]] std::uint32_t GetNumKeywords() const;
 		[[nodiscard]] bool          HasKeyword(BGSKeyword* keyword) const;
 		[[nodiscard]] bool          HasKeywordString(std::string_view a_editorID);
-		bool                        RemoveKeyword(RE::BGSKeyword* keyword);
+		bool                        RemoveKeyword(BGSKeyword* keyword);
 
 		// members
 		BSTArray<BGSFormFolderKeywordList*> formFolderKeywordLists;  // 10

--- a/include/RE/B/BGSKeywordForm.h
+++ b/include/RE/B/BGSKeywordForm.h
@@ -28,6 +28,7 @@ namespace RE
 		[[nodiscard]] bool          ContainsKeywordString(std::string_view a_editorID);
 		void                        ForEachKeyword(std::function<BSContainer::ForEachResult(BGSKeyword*)> a_callback);
 		[[nodiscard]] std::uint32_t GetNumKeywords() const;
+		[[nodiscard]] bool          HasKeyword(BGSKeyword* keyword) const;
 		[[nodiscard]] bool          HasKeywordString(std::string_view a_editorID);
 		bool                        RemoveKeyword(RE::BGSKeyword* keyword);
 

--- a/include/RE/B/BSTArray.h
+++ b/include/RE/B/BSTArray.h
@@ -182,6 +182,7 @@ namespace RE
 			for (const auto& i : a_rhs) {
 				emplace_back(i);
 			}
+			return *this;
 		}
 
 		BSTArray& operator=(BSTArray&& a_rhs)

--- a/src/RE/B/BGSKeywordForm.cpp
+++ b/src/RE/B/BGSKeywordForm.cpp
@@ -94,7 +94,7 @@ namespace RE
 		return result;
 	}
 
-	bool RE::BGSKeywordForm::RemoveKeyword(RE::BGSKeyword* keyword)
+	bool BGSKeywordForm::RemoveKeyword(RE::BGSKeyword* keyword)
 	{
 		if (!keyword) {
 			return false;

--- a/src/RE/B/BGSKeywordForm.cpp
+++ b/src/RE/B/BGSKeywordForm.cpp
@@ -4,6 +4,22 @@
 
 namespace RE
 {
+	bool RE::BGSKeywordForm::AddKeyword(RE::BGSKeyword* keyword)
+	{
+		if (!keyword) {
+			return false;
+		}
+
+		for (const auto& existing : keywords) {
+			if (existing == keyword) {
+				return false;
+			}
+		}
+
+		keywords.push_back(keyword);
+		return true;
+	}
+
 	bool BGSKeywordForm::ContainsKeywordString(std::string_view a_editorID)
 	{
 		bool result{};
@@ -49,5 +65,21 @@ namespace RE
 			return BSContainer::ForEachResult::kContinue;
 		});
 		return result;
+	}
+
+	bool RE::BGSKeywordForm::RemoveKeyword(RE::BGSKeyword* keyword)
+	{
+		if (!keyword) {
+			return false;
+		}
+
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			if (*it == keyword) {
+				keywords.erase(it);
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/RE/B/BGSKeywordForm.cpp
+++ b/src/RE/B/BGSKeywordForm.cpp
@@ -4,7 +4,7 @@
 
 namespace RE
 {
-	bool RE::BGSKeywordForm::AddKeyword(RE::BGSKeyword* keyword)
+	bool BGSKeywordForm::AddKeyword(RE::BGSKeyword* keyword)
 	{
 		if (!keyword) {
 			return false;

--- a/src/RE/B/BGSKeywordForm.cpp
+++ b/src/RE/B/BGSKeywordForm.cpp
@@ -4,7 +4,7 @@
 
 namespace RE
 {
-	bool RE::BGSKeywordForm::AddKeyword(RE::BGSKeyword* keyword)
+	bool BGSKeywordForm::AddKeyword(BGSKeyword* keyword)
 	{
 		if (!keyword) {
 			return false;
@@ -55,7 +55,7 @@ namespace RE
 		return keywords.size();
 	}
 
-	bool RE::BGSKeywordForm::HasKeyword(BGSKeyword* keyword) const
+	bool BGSKeywordForm::HasKeyword(BGSKeyword* keyword) const
 	{
 		if (!keyword) {
 			return false;
@@ -94,7 +94,7 @@ namespace RE
 		return result;
 	}
 
-	bool RE::BGSKeywordForm::RemoveKeyword(RE::BGSKeyword* keyword)
+	bool BGSKeywordForm::RemoveKeyword(BGSKeyword* keyword)
 	{
 		if (!keyword) {
 			return false;

--- a/src/RE/B/BGSKeywordForm.cpp
+++ b/src/RE/B/BGSKeywordForm.cpp
@@ -55,7 +55,7 @@ namespace RE
 		return keywords.size();
 	}
 
-	bool RE::BGSKeywordForm::HasKeyword(BGSKeyword* keyword) const
+	bool BGSKeywordForm::HasKeyword(BGSKeyword* keyword) const
 	{
 		if (!keyword) {
 			return false;

--- a/src/RE/B/BGSKeywordForm.cpp
+++ b/src/RE/B/BGSKeywordForm.cpp
@@ -55,6 +55,33 @@ namespace RE
 		return keywords.size();
 	}
 
+	bool RE::BGSKeywordForm::HasKeyword(BGSKeyword* keyword) const
+	{
+		if (!keyword) {
+			return false;
+		}
+
+		for (const auto& existing : keywords) {
+			if (existing == keyword) {
+				return true;
+			}
+		}
+
+		for (const auto& formFolderKeywordList : formFolderKeywordLists) {
+			if (!formFolderKeywordList) {
+				continue;
+			}
+
+			for (const auto& existing : formFolderKeywordList->keywords) {
+				if (existing == keyword) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	bool BGSKeywordForm::HasKeywordString(std::string_view a_editorID)
 	{
 		bool result{};


### PR DESCRIPTION
This PR fixes an issue in BSTArray where the copy and move assignment operators were missing a return value, causing compiler error C4716.

Changes:
- Fixed BSTArray::operator= by adding missing `return *this`
- Added AddKeyword and RemoveKeyword to BGSKeywordForm
- Added HasKeyword helper function
