### PR TITLE
New BSStringPool GetEntry and GetEntryW IDs

### DIFF
--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -364,8 +364,8 @@ namespace RE::ID
 			inline constexpr REL::ID GetSingleton{ 139337 };
 		}
 
-		inline constexpr REL::ID GetEntry{ 139352 };
-		inline constexpr REL::ID GetEntryW{ 139354 };
+		inline constexpr REL::ID GetEntry{ 1186742 };
+		inline constexpr REL::ID GetEntryW{ 1186743 };
 	}
 
 	namespace BSStorage


### PR DESCRIPTION
Change IDs that are now missing in update from 1.16.242 to 1.16.244 (AddLib v21 to v22).