### PR TITLE
subtitle/camera/handle IDs and fix BSTEventSource::Notify

### DIFF
--- a/include/RE/B/BSPointerHandle.h
+++ b/include/RE/B/BSPointerHandle.h
@@ -136,9 +136,10 @@ namespace RE
 	public:
 		static bool GetSmartPointer(const BSPointerHandle<T>& a_in, NiPointer<T>& a_out)
 		{
-			using func_t = bool (*)(const BSPointerHandle<T>& a_in, NiPointer<T>& a_out);
+			using func_t = NiPointer<T>& (*)(NiPointer<T>& a_out, const BSPointerHandle<T>& a_in);
 			static REL::Relocation<func_t> func{ ID::BSPointerHandleManagerInterface::GetSmartPointer };
-			return func(a_in, a_out);
+			func(a_out, a_in);
+			return static_cast<bool>(a_out);
 		}
 
 		static NiPointer<T> GetSmartPointer(const BSPointerHandle<T>& a_in)

--- a/include/RE/B/BSTEvent.h
+++ b/include/RE/B/BSTEvent.h
@@ -51,11 +51,12 @@ namespace RE
 	public:
 		~BSTEventSource() override = default;  // 00
 
-		void Notify(void* a_event)
+		void Notify(const Event& a_event)
 		{
-			using func_t = decltype(&BSTEventSource::Notify);
+			NotifyVisitor visitor{ &a_event, this };
+			using func_t = void (*)(BSTEventSource*, void*);
 			static REL::Relocation<func_t> func{ ID::BSTEventSource::Notify };
-			return func(this, a_event);
+			func(this, &visitor);
 		}
 
 		void RegisterSink(BSTEventSink<Event>* a_sink)
@@ -78,6 +79,25 @@ namespace RE
 		std::uint32_t                 unk1C;  // 1C
 		std::uint32_t                 unk20;  // 20
 		std::uint32_t                 unk24;  // 24
+
+	private:
+		struct NotifyVisitor
+		{
+			NotifyVisitor(const Event* a_event, BSTEventSource* a_source) noexcept : event(a_event), source(a_source) {}
+
+			virtual ~NotifyVisitor() = default;  // 00
+			virtual void Unk01() {}  // 01
+
+			virtual BSEventNotifyControl Invoke(BSTEventDetail::SinkBase* a_sink)  // 02
+			{
+				return static_cast<BSTEventSink<Event>*>(a_sink)->ProcessEvent(*event, source);
+			}
+
+			// members
+			const Event*    event;   // 08
+			BSTEventSource* source;  // 10
+		};
+
 	};
 	static_assert(sizeof(BSTEventSource<void*>) == 0x28);
 

--- a/include/RE/E/Events.h
+++ b/include/RE/E/Events.h
@@ -3034,7 +3034,12 @@ namespace RE
 				static REL::Relocation<func_t> func{ ID::ShowSubtitleEvent::Event::GetEventSource };
 				return func();
 			}
+
+			const char* subtitleText{ nullptr };  // 00 
+			const char* speakerName{ nullptr };   // 08
+			bool        isPlayer{ false };        // 10
 		};
+		static_assert(sizeof(Event) == 0x18);
 	};
 
 	struct SkillsMenu_Accept

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -926,6 +926,14 @@ namespace RE::ID
 		inline constexpr REL::ID GetForForm{ 47393 };  // generic form-component lookup helper
 	}
 
+	namespace FreeCameraInputContext
+	{
+		inline constexpr REL::ID Manager{ 938003 };
+		inline constexpr REL::ID Descriptor{ 894502 };
+		inline constexpr REL::ID PushContext{ 124144 };
+		inline constexpr REL::ID PopContext{ 124143 };
+	}
+
 	namespace GameMenuBase
 	{
 		inline constexpr REL::ID ctor{ 0 };   // 130577
@@ -1457,7 +1465,8 @@ namespace RE::ID
 		inline constexpr REL::ID Singleton{ 937788 };
 		inline constexpr REL::ID ForceFirstPerson{ 113397 };
 		inline constexpr REL::ID ForceThirdPerson{ 113398 };
-		inline constexpr REL::ID SetCameraState{ 0 };  // 166078
+		inline constexpr REL::ID SetCameraState{ 113375 };
+		inline constexpr REL::ID ToggleFreeCameraMode{ 113409 };
 		inline constexpr REL::ID QCameraEquals{ 0 };   // 166081
 	}
 

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -963,7 +963,7 @@ namespace RE::ID
 
 	namespace HideSubtitleEvent::Event
 	{
-		inline constexpr REL::ID GetEventSource{ 0 };  // 133630
+		inline constexpr REL::ID GetEventSource{ 86875 };
 	}
 
 	namespace HourPassed::Event
@@ -1888,7 +1888,7 @@ namespace RE::ID
 
 	namespace ShowSubtitleEvent::Event
 	{
-		inline constexpr REL::ID GetEventSource{ 0 };  // 133631
+		inline constexpr REL::ID GetEventSource{ 86874 };
 	}
 
 	namespace SkillsMenu_Accept

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -278,7 +278,7 @@ namespace RE::ID
 
 	namespace BSPointerHandleManagerInterface
 	{
-		inline constexpr REL::ID GetSmartPointer{ 0 };  // 72432
+		inline constexpr REL::ID GetSmartPointer{ 35638 };
 	}
 
 	namespace BSReadWriteLock

--- a/include/RE/P/PlayerCamera.h
+++ b/include/RE/P/PlayerCamera.h
@@ -111,6 +111,13 @@ namespace RE
 			return func(this, a_cameraState);
 		}
 
+		void ToggleFreeCameraMode(std::uint32_t a_cameraStateIndex, bool a_flag)
+		{
+			using func_t = decltype(&PlayerCamera::ToggleFreeCameraMode);
+			static REL::Relocation<func_t> func{ ID::PlayerCamera::ToggleFreeCameraMode };
+			return func(this, a_cameraStateIndex, a_flag);
+		}
+
 		bool QCameraEquals(CameraState a_cameraState) const
 		{
 			return (currentState == cameraStates[a_cameraState]);


### PR DESCRIPTION
BSPointerHandleManagerInterface::GetSmartPointer
- resolve id
- fix signature, engine returns smart pointer via out-param

BSTEventSource::Notify
- Take a typed `const Event&` instead of `void*`.
- implement engines visitor-based dispatch. (Accepts visitor object with Invoke called per sink)

Subtitle events (`ShowSubtitleEvent` / `HideSubtitleEvent`)

PlayerCamera 
- resolve SetCameraState and ToggleFreeCameraMode
- Add FreeCameraInputContext to replicate tfc flow
