### PR TITLE
RE prefix for RTTI and VTABLE macros

### DIFF
--- a/include/RE/IDs_VTABLE.h
+++ b/include/RE/IDs_VTABLE.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define SF_VTABLE(VTBL) \
-	inline static constexpr auto VTABLE = VTABLE::VTBL
+	inline static constexpr auto VTABLE = RE::VTABLE::VTBL
 
 namespace RE
 {


### PR DESCRIPTION
These macros are placed outside of RE namespace and should have the prefix, just like SF_EXTRADATATYPE.
```
namespace Whatever {
    SF_RTTI_VTABLE(ExtraLeveledCreature); // error, RE:: is missing
    SF_EXTRADATATYPE(LeveledCreature); // valid
}
```